### PR TITLE
[REF] requirements: remove m2crypto from requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 pyOpenSSL
-M2Crypto
 httplib2>=0.7
 git+https://github.com/pysimplesoap/pysimplesoap@a330d9c4af1b007fe1436f979ff0b9f66613136e
 # fpdf>=1.7.2


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

M2Crypto dependency is causing that CI gitlab fail, it showing this traceback:

```
  SWIG/_m2crypto_wrap.c:31818:5: warning: (near initialization for ‘SwigPyBuiltin___cbd_t_type.as_buffer.bf_releasebuffer’) [enabled by default]
    SWIG/_m2crypto_wrap.c: In function ‘PyInit__m2crypto’:
    SWIG/_m2crypto_wrap.c:33020:108: error: ‘X509_V_FLAG_PARTIAL_CHAIN’ undeclared (first use in this function)
       SWIG_Python_SetConstant(d, d == md ? public_interface : NULL, "VERIFY_PARTIAL_CHAIN",SWIG_From_int((int)(X509_V_FLAG_PARTIAL_CHAIN)));
                                                                                                                ^
    SWIG/_m2crypto_wrap.c:33020:108: note: each undeclared identifier is reported only once for each function it appears in
    SWIG/_m2crypto_wrap.c:33022:108: error: ‘X509_V_FLAG_TRUSTED_FIRST’ undeclared (first use in this function)
       SWIG_Python_SetConstant(d, d == md ? public_interface : NULL, "VERIFY_TRUSTED_FIRST",SWIG_From_int((int)(X509_V_FLAG_TRUSTED_FIRST)));
                                                                                                                ^
    error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
    ----------------------------------------
ERROR: Command errored out with exit status 1: /.repo_requirements/virtualenv/python3.6/bin/python -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-yu93tzsn/m2crypto_00d212c196c34b30863aaa73827d0e38/setup.py'"'"'; __file__='"'"'/tmp/pip-install-yu93tzsn/m2crypto_00d212c196c34b30863aaa73827d0e38/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-8nz_8fwm/install-record.txt --single-version-externally-managed --compile --install-headers /.repo_requirements/virtualenv/python3.6/include/site/python3.6/M2Crypto Check the logs for full command output.
Traceback (most recent call last):
  File "/root/maintainer-quality-tools/travis/clone_oca_dependencies", line 124, in <module>
    run(home, build_dir)
  File "/root/maintainer-quality-tools/travis/clone_oca_dependencies", line 111, in run
    subprocess.check_call(command)
  File "/usr/lib/python2.7/subprocess.py", line 541, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['pip', 'install', '--no-binary', 'pycparser', '-Ur', '/root/odoo-argentina/requirements.txt']' returned non-zero exit status 1
clone_result=$?
Error cloning dependencies
if [ "$clone_result" != "0"  ]; then
    echo "Error cloning dependencies"
    exit $clone_result
fi;
```

Current behavior before PR:

Desired behavior after PR is merged:
CI gitlab pass without errors.

-- I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
